### PR TITLE
Navigation Update for Events Page

### DIFF
--- a/app/controllers/shifts_controller.rb
+++ b/app/controllers/shifts_controller.rb
@@ -39,7 +39,7 @@ class ShiftsController < ApplicationController
   def update
     respond_to do |format|
       if @shift.update(shift_params)
-        format.html { redirect_to shift_url(@shift), notice: "Shift was successfully updated." }
+        format.html { redirect_to event_url(@shift.Event_id), notice: "Shift was successfully updated." }
         format.json { render :show, status: :ok, location: @shift }
       else
         format.html { render :edit, status: :unprocessable_entity }

--- a/app/views/events/edit.html.erb
+++ b/app/views/events/edit.html.erb
@@ -2,5 +2,4 @@
 
 <%= render 'form', event: @event %>
 
-<%= link_to 'Show', @event %> |
 <%= link_to 'Back', events_path %>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -2,69 +2,74 @@
 
 <p id="notice"><%= notice %></p>
 
-<p>
-  <strong>Type:</strong>
-    <%if @event.Type == 0 %>
-      <td>Club Meeting</td>
-    <%else%>
-      <td>Volunteer Event</td>
-    <%end%>
-</p>
-
-<p>
-  <strong>Date:</strong>
-  <%= @event.Date %>
-</p>
-
-<p>
-  <strong>Name:</strong>
-  <%= @event.Name %>
-</p>
 
 
-<p>
-  <strong>Start:</strong>
-  <%= @event.Start.strftime("%I:%M %p") %>
-</p>
 
-<p>
-  <strong>End:</strong>
-  <%= @event.End.strftime("%I:%M %p") %>
-</p>
 
-<p>
-<ul>
-  <% @event.qr_code_attendance do |file| %>
-    <li>
-      <% if file.representable? %>
-        <%= image_tag file.representation(resize_to_limit: [100, 100]) %>
-      <% else %>
-        <%= link_to rails_blob_path(file, disposition: "attachment") do %>
-          <%= image_tag "placeholder.png", alt: "Download file" %>
+
+<div class="container">
+  <div class="row">
+    <div class="col-sm">
+      <p>
+        <strong>Name:</strong>
+        <%= @event.Name %>
+      </p>
+
+      <p>
+        <strong>Type:</strong>
+          <%if @event.Type == 0 %>
+            <td>Club Meeting</td>
+          <%else%>
+            <td>Volunteer Event</td>
+          <%end%>
+      </p>
+
+      <p>
+        <strong>Date:</strong>
+        <%= @event.Date %>
+      </p>
+
+      <p>
+        <strong>Start:</strong>
+        <%= @event.Start.strftime("%I:%M %p") %>
+      </p>
+
+      <p>
+        <strong>End:</strong>
+        <%= @event.End.strftime("%I:%M %p") %>
+      </p>
+    </div>
+    <div class="col-sm">
+      <ul>
+        <% @event.qr_code_attendance do |file| %>
+          <li>
+            <% if file.representable? %>
+              <%= image_tag file.representation(resize_to_limit: [100, 100]) %>
+            <% else %>
+              <%= link_to rails_blob_path(file, disposition: "attachment") do %>
+                <%= image_tag "placeholder.png", alt: "Download file" %>
+              <% end %>
+            <% end %>
+          </li>
         <% end %>
-      <% end %>
-    </li>
-  <% end %>
-</ul>
-</p>
+      </ul>
 
+      <p><strong>Sign Up:</strong></p>
+      <p><%= image_tag(@event.qr_code_shift)%></p>
+
+    </div>
+    <div class="col-sm">
+      <p><strong>Sign In:</strong></p>
+      <p><%= image_tag(@event.qr_code_attendance) %></p>
+    </div>
+  </div>
+</div>
+
+<br>
 <br>
 
 <p>
-  <strong>Sign Up:</strong>
-  <%= image_tag(@event.qr_code_shift)%>
-</p>
-
-<p>
-  <strong>Sign In:</strong>
-  <%= image_tag(@event.qr_code_attendance) %>
-</p>
-
-<br>
-
-
-<p>
-<strong>Shifts For This Event:</strong>
+<strong>Shifts</strong>
 </p>
 <%= link_to 'New Shift', new_shift_path, :class => 'btn btn-primary' %>
 <table class="table">
@@ -85,7 +90,6 @@
         <td><%= shift.End.strftime("%I:%M %p") %></td>
         <td><%= shift.Shift_Cap %></td>
         <td><%= shift.Shift_Cap - Attendance.where(Shift_id: shift.id).size %></td>
-        <td><%= link_to 'Details', shift %></td>
         <td><%= link_to 'Edit', edit_shift_path(shift) %></td>
         <td><%= link_to 'Delete', shift, method: :delete, data: { confirm: 'Are you sure?' } %></td>
       </tr>
@@ -98,7 +102,7 @@
 
 <%if @event.Date > Date.parse("2021-10-01") %>
 <p>
-  <strong>Members Signed Up For This Event</strong>
+  <strong>Sign Up</strong>
   </p>
   <table class="table">
     <thead>
@@ -127,7 +131,7 @@
 <br>
 
 <p>
-<strong>Attendances For This Event</strong>
+<strong>Attendance</strong>
 </p>
 <%= link_to 'New Attendance', new_attendance_path, :class => 'btn btn-primary' %>
 <table class="table">

--- a/app/views/shifts/edit.html.erb
+++ b/app/views/shifts/edit.html.erb
@@ -2,5 +2,4 @@
 
 <%= render 'form', shift: @shift %>
 
-<%= link_to 'Show', @shift %> |
-<%= link_to 'Back', events_path %>
+<%= link_to 'Back', :back %>

--- a/app/views/shifts/show.html.erb
+++ b/app/views/shifts/show.html.erb
@@ -2,12 +2,7 @@
 
 <p>
   <strong>Event:</strong>
-  <%= @shift.Event_id %>
-</p>
-
-<p>
-  <strong>Title:</strong>
-  Shift Title
+  <%= Event.find(@shift.Event_id).Name %>
 </p>
 
 <p>
@@ -25,5 +20,4 @@
   <%= @shift.Shift_Cap %>
 </p>
 
-<%= link_to 'Edit', edit_shift_path(@shift) %> |
-<%= link_to 'Back', events_path %>
+<%= link_to 'Back', :back %>


### PR DESCRIPTION
This pull updated the navigation in the events page. This includes back buttons directing to a more intuitive page, deleting of redunctant show and edit buttons. and some minor layout changes