### PR TITLE
Table Sorting + Crate Shift Redirection Update

### DIFF
--- a/app/controllers/members_controller.rb
+++ b/app/controllers/members_controller.rb
@@ -3,38 +3,66 @@ class MembersController < ApplicationController
   before_action :authenticate_user!
   before_action :check_officer_privelege
 
+
   # GET /members or /members.json
   # used same code from show, maybe make helper method to avoid redundancy
   def index
-    #@members = Member.all
+
+    #SORT BY LAST NAME
     if params[:sort] == "Last_Name"
       @members = Member.order(:Last_Name)
+      @toggle = 0
     elsif params[:sort] == "Last_Name_Desc"
       @members = Member.order(Last_Name: :desc)
+      @toggle = 11
+
+    #SORT BY ROLE
     elsif params[:sort] == "Role"
       @members = Member.order(:Role)
+      @toggle = 2
+    elsif params[:sort] == "Role_Desc"
+      @members = Member.order(Role: :desc)
+      @toggle = 33
+
+    #SORT BY EMAIL
     elsif params[:sort] == "Email"
       @members = Member.order(:Email)
+      @toggle = 4
+    elsif params[:sort] == "Email_Desc"
+      @members = Member.order(Email: :desc)
+      @toggle = 55
+
+    #SORT BY SHIRT
     elsif params[:sort] == "Shirt"
       @members = Member.order(:Shirt_Size)
+      @toggle = 6
+    elsif params[:sort] == "Shirt_Desc"
+      @members = Member.order(Shirt_Size: :desc)
+      @toggle = 77
+
+    #SORT BY YEAR
     elsif params[:sort] == "Year"
-      puts "HEYY"
       @members = Member.order(:year)
-      puts @members
+      @toggle = 8
+    elsif params[:sort] == "Year_Desc"
+      @members = Member.order(year: :desc)
+      @toggle = 99
+      
+    #SORT BY HOURS
     elsif params[:sort] == "Hours"
-      puts "HIHIHI"
       hoursList = Attendance.group(:Member_id).sum(:Hours).sort_by{|e| -e[1]}.collect{|imd| imd[0]}
       @members = Member.find(hoursList)+ Member.where.not(id: hoursList)
-      @members.each do |single|
-        puts single.First_Name
-      end
-      puts "HIHIHIDDDD"
+      @toggle = 10
+    elsif params[:sort] == "Hours_Desc"
+      hoursList = Attendance.group(:Member_id).sum(:Hours).sort_by{|e| -e[1]}.collect{|imd| imd[0]}
+      hoursList = hoursList.reverse()
+      @members =  Member.where.not(id: hoursList) + Member.find(hoursList)
+      @toggle = 14
+
     else
-      puts "HEYY"
       @members = Member.all
-      puts @members.where(year: 4)
-      puts "HEDDD"
     end
+
   #Attendance.select(:Hours, :Member_id).group(:Member_id).sum(:Hours)
   @MemberAttendances = Attendance.where(Member_id: params[:id]) 
     @hours = 0

--- a/app/controllers/shifts_controller.rb
+++ b/app/controllers/shifts_controller.rb
@@ -27,7 +27,11 @@ class ShiftsController < ApplicationController
 
     respond_to do |format|
       if @shift.save
-        format.html { redirect_to new_shift_path, notice: "Shift was successfully created." }
+        puts "HEYY22"
+        puts params[:Event_id]
+        puts shift_params[:Event_id]
+        @event = Event.find(shift_params[:Event_id])
+        format.html { redirect_to event_url(@event), notice: "Shift was successfully created." }
         format.json { render :show, status: :created, location: @shift }
       else
         format.html { render :new, status: :unprocessable_entity }

--- a/app/controllers/shifts_controller.rb
+++ b/app/controllers/shifts_controller.rb
@@ -27,9 +27,6 @@ class ShiftsController < ApplicationController
 
     respond_to do |format|
       if @shift.save
-        puts "HEYY22"
-        puts params[:Event_id]
-        puts shift_params[:Event_id]
         @event = Event.find(shift_params[:Event_id])
         format.html { redirect_to event_url(@event), notice: "Shift was successfully created." }
         format.json { render :show, status: :created, location: @shift }

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -51,7 +51,7 @@
   <div class="d-flex align-items-center gap-3 mb-2">
     <h1 style="margin: 0">Shifts</h1>
 
-    <%= link_to 'New Shift', new_shift_path, :class => 'btn btn-primary btn-new' %>
+    <%= link_to 'New Shift', new_shift_path(:event_id => @event.id), :class => 'btn btn-primary btn-new' %>
   </div>
 
   <!--SHIFTS TABLE-->

--- a/app/views/members/index.html.erb
+++ b/app/views/members/index.html.erb
@@ -16,47 +16,95 @@
   <%= link_to "New Member", new_member_path, class: "btn btn-primary btn-new" %>
 </div>
 
+<!--CURRENT MEMBERS TABLE-->
 <div class="table-ruby table-responsive"> <%#table-responsive shows white at bottom of table %>
   <table class="table table-hover table-striped">
     <thead>
       <tr>
+        <!--NAME COLUMN-->
         <th style="width: 16rem">
           Name 
-          <%= link_to members_path+"?sort=Last_Name", :class => 'name_links', :sort => "Last_Name" do %>
-            <%= image_tag "sort.svg", style: 'height:1rem; width:1rem;' %>
-          <% end %>
+          <%if (@toggle == nil || @toggle != 1) &&  @toggle != 0%>
+            <%= link_to members_path+"?sort=Last_Name", :class => 'name_links' do %>
+              <%= image_tag "sort.svg", style: 'height:1rem; width:1rem;' %>
+            <% end %>
+          <%elsif @toggle == 0%>
+            <%= link_to members_path+"?sort=Last_Name_Desc", :class => 'name_links' do %>
+              <%= image_tag "sort.svg", style: 'height:1rem; width:1rem;' %>
+            <% end %>
+          <%end%>
         </th>
+
+        <!--ROLE COLUMN-->
         <th>
           Role 
-          <%= link_to members_path+"?sort=Role", :class => 'name_links', :sort => "Role" do %>
-            <%= image_tag "sort.svg", style: 'height:1rem; width:1rem;' %>
-          <% end %>
+          <%if (@toggle == nil || @toggle != 3) &&  @toggle != 2%>
+            <%= link_to members_path+"?sort=Role", :class => 'name_links' do %>
+              <%= image_tag "sort.svg", style: 'height:1rem; width:1rem;' %>
+            <% end %>
+          <%elsif @toggle == 2%>
+            <%= link_to members_path+"?sort=Role_Desc", :class => 'name_links' do %>
+              <%= image_tag "sort.svg", style: 'height:1rem; width:1rem;' %>
+            <% end %>
+          <%end%>
         </th>
+
+        <!--EMAIL COLUMN-->
         <th style="width: 18rem">
           Email 
-          <%= link_to members_path+"?sort=Email", :class => 'name_links', :sort => "Email" do %>
-            <%= image_tag "sort.svg", style: 'height:1rem; width:1rem;' %>
-          <% end %>
+          <%if (@toggle == nil || @toggle != 5) &&  @toggle != 4%>
+            <%= link_to members_path+"?sort=Email", :class => 'name_links' do %>
+              <%= image_tag "sort.svg", style: 'height:1rem; width:1rem;' %>
+            <% end %>
+          <%elsif @toggle == 4%>
+            <%= link_to members_path+"?sort=Email_Desc", :class => 'name_links' do %>
+              <%= image_tag "sort.svg", style: 'height:1rem; width:1rem;' %>
+            <% end %>
+          <%end%>
         </th>
+
+
         <th>Fall Dues</th>
         <th>Spring Dues</th>
+
+        <!--SHIRT SIZE COLUMN-->
         <th>
           Shirt Size 
-          <%= link_to members_path+"?sort=Shirt", :class => 'name_links', :sort => "Shirt" do %>
-            <%= image_tag "sort.svg", style: 'height:1rem; width:1rem;' %>
-          <% end %>
+          <%if (@toggle == nil || @toggle != 7) &&  @toggle != 6%>
+            <%= link_to members_path+"?sort=Shirt", :class => 'name_links' do %>
+              <%= image_tag "sort.svg", style: 'height:1rem; width:1rem;' %>
+            <% end %>
+          <%elsif @toggle == 6%>
+            <%= link_to members_path+"?sort=Shirt_Desc", :class => 'name_links' do %>
+              <%= image_tag "sort.svg", style: 'height:1rem; width:1rem;' %>
+            <% end %>
+          <%end%>
         </th>
+
         <th>
           Year 
-          <%= link_to members_path+"?sort=Year", :class => 'name_links', :sort => "Year" do %>
-            <%= image_tag "sort.svg", style: 'height:1rem; width:1rem;' %>
-          <% end %>
+          <%if (@toggle == nil || @toggle != 9) &&  @toggle != 8%>
+            <%= link_to members_path+"?sort=Year", :class => 'name_links' do %>
+              <%= image_tag "sort.svg", style: 'height:1rem; width:1rem;' %>
+            <% end %>
+          <%elsif @toggle == 8%>
+            <%= link_to members_path+"?sort=Year_Desc", :class => 'name_links' do %>
+              <%= image_tag "sort.svg", style: 'height:1rem; width:1rem;' %>
+            <% end %>
+          <%end%>
         </th>
+
         <th>
           Total Hours 
-          <%= link_to members_path+"?sort=Hours", :class => 'name_links', :sort => "Hours" do %>
-            <%= image_tag "sort.svg", style: 'height:1rem; width:1rem;' %>
-          <% end %>
+          <%if (@toggle == nil || @toggle != 15) &&  @toggle != 10%>
+            <%= link_to members_path+"?sort=Hours", :class => 'name_links' do %>
+              <%= image_tag "sort.svg", style: 'height:1rem; width:1rem;' %>
+            <% end %>
+          <%elsif @toggle == 10%>
+            <%= link_to members_path+"?sort=Hours_Desc", :class => 'name_links' do %>
+              <%= image_tag "sort.svg", style: 'height:1rem; width:1rem;' %>
+            <% end %>
+          <%end%>
         </th>
         <th class="actions">Action</th>
       </tr>


### PR DESCRIPTION
In the Members Table, clicking the sort button sorts column ascending, now clicking it again will sort the column descending. this is infinitely togglable.

The issue of the back button when creating a new shift has been resolved, creating a shift now redirects you to the corresponding event show page, and back button works as intended